### PR TITLE
[RFC] Prevent faulty lines in powquty.log

### DIFF
--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -114,13 +114,13 @@ int has_max_size(char *powquty_path, off_t max_size) {
 
 /*
  * check if Harmonic values are in a reasonable range
- * returns 1 if a value is 10 or more, else 0
+ * returns 0 if a value is 10 or more, else 1
  */
-int is_faulty_line(PQResult pqResult) {
+int is_valid_input(PQResult pqResult) {
 	for (int i = 1; i < 7; i++)
 		if (pqResult.Harmonics[i] >= 10)
-			return 1;
-	return 0;
+			return 0;
+	return 1;
 }
 
 void store_to_file(PQResult pqResult, char *powquty_path) {
@@ -129,7 +129,7 @@ void store_to_file(PQResult pqResult, char *powquty_path) {
 	long long ts = get_curr_time_in_milliseconds();
 	int ts_sec = get_curr_time_in_seconds();
 
-	if (is_faulty_line(pqResult)) {
+	if (!is_valid_input(pqResult)) {
 		fclose(pf);
 		return;
 	}

--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -112,11 +112,28 @@ int has_max_size(char *powquty_path, off_t max_size) {
 	return 0;
 }
 
+/*
+ * check if Harmonic values are in a reasonable range
+ * returns 1 if a value is 10 or more, else 0
+ */
+int is_faulty_line(PQResult pqResult) {
+	for (int i = 1; i < 7; i++)
+		if (pqResult.Harmonics[i] >= 10)
+			return 1;
+	return 0;
+}
+
 void store_to_file(PQResult pqResult, char *powquty_path) {
 	FILE* pf;
 	pf = fopen(powquty_path,"a");
 	long long ts = get_curr_time_in_milliseconds();
 	int ts_sec = get_curr_time_in_seconds();
+
+	if (is_faulty_line(pqResult)) {
+		fclose(pf);
+		return;
+	}
+
 	fprintf(pf,
 			"%s,%d,%lld,3,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f\n",
 			"DEV_UUID",


### PR DESCRIPTION
The first line of received/calculated data do not match with the line length of the rest of the lines in the log file. The values  differ from the rest as well.

invalid line: DEV_UUID,1486160690,1486160690020,3,188.903976,50.092415,16.239849,9.278195,5.872845,18.093172,9.937242,9.361388,8.366595                                                              

valid line:
DEV_UUID,1486160691,1486160691020,3,232.321533,50.031239,1.187999,1.308120,1.502470,1.073430,0.855245,0.939552,1.905430

This occured on start of powqutyd so far, but @neez34 pointed out, that this could happen any time.
This will check if the values in the pqResult.Harmonics array are single digit only.
Log file processing will be easier if all lines are of the same length.

Is this reasonable to do, or is there a better way to handle faulty lines?

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>