### PR TITLE
[RFC] Round Robin log file write

### DIFF
--- a/powqutyd/files/include/helper.h
+++ b/powqutyd/files/include/helper.h
@@ -12,7 +12,7 @@
 
 long long get_curr_time_in_milliseconds();
 
-int get_curr_time_in_seconds();
+long get_curr_time_in_seconds();
 
 short get_short_val(unsigned char* buf);
 

--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -92,7 +92,7 @@ void print_PQ_Error(PQ_ERROR err) {
 }
 
 /*
- * returns content from comma separated line
+ * get entry in csv line
  * @line: comma separated line, to parse
  * @entry: position in line
  * return: token if found, else NULL
@@ -110,7 +110,7 @@ char * get_entry(char* line, int entry) {
 /*
  * get the last line of a file
  * @file: file to get line from
- * @char_count: offset to get the start of line
+ * @char_count: offset(number of characters) to get the start of line
  * return: complete last line of file
  */
 char * get_last_line(FILE *file, ssize_t char_count) {
@@ -129,9 +129,9 @@ char * get_last_line(FILE *file, ssize_t char_count) {
 
 /*
  * get the number of characters in a regular line in file
- * this assumes, that _only_ the first line in a file may not match the others
+ * this assumes, that all lines have the same character count
  * @file: file to check for line length
- * return: returns regular line length
+ * return: returns character count of first line
  */
 ssize_t get_character_count(FILE *file) {
 	char *line = NULL;
@@ -153,7 +153,7 @@ ssize_t get_character_count(FILE *file) {
 /*
  * checks if the log file can be rewritten from start, or has to be resumed
  * @file: file to check
- * @char_count: number of chars in regular line
+ * @char_count: number of chars in a line
  * return 0 if file write has to be resumed, 1 if the first entry is the oldest
  */
 int is_outdated(FILE *file, ssize_t char_count) {
@@ -205,9 +205,9 @@ int has_max_size(char *powquty_path, off_t max_size) {
 }
 
 /*
- * calculate real number of a line
+ * calculate real number of a line(starting with 1)
  * @offset: offset of line in file
- * @char_count number of characters in line
+ * @char_count number of characters in a line
  * return the line number
  */
 long get_line_number(long offset, ssize_t char_count) {
@@ -217,7 +217,7 @@ long get_line_number(long offset, ssize_t char_count) {
 
 /*
  * get an Entry(timestamp) from a line
- * the position of the line hast to be set before calling this function
+ * the position of the line has to be set before calling this function
  * @file file to read from
  * return timestam as integer
  */
@@ -233,9 +233,10 @@ int get_line_entry(FILE *file) {
 
 /*
  * set the position to resume write operations after powqutyd stopped
+ * uses logarithmic search to get the latest timestamp
  * @file: file to write to
- * @u_bound position closest to file start to check for last write
- * @l_bound lower bound for last timestamp check
+ * @u_bound upper boundary for interval
+ * @l_bound lower boundary for latest timestamp search
  * @char_count: length of line to calculate offset
  */
 void set_position(FILE *file, long u_bound, long l_bound, ssize_t char_count) {

--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -98,7 +98,7 @@ void print_PQ_Error(PQ_ERROR err) {
  * @entry: position in line
  * return: token if found, else NULL
  */
-char * get_entry(char* line, int entry) {
+char * get_entry_from_line_position(char* line, int entry) {
 	char* token;
 	for (token = strtok(line, ","); token && *token;
 	     token = strtok(NULL, ",\n")) {
@@ -165,11 +165,11 @@ int is_outdated(FILE *file, ssize_t char_count) {
 
 	fseek(file, 0, SEEK_SET);
 	getline(&line, &len, file);
-	first_time = atoi(get_entry(line, TIME_STAMP));
+	first_time = atoi(get_entry_from_line_position(line, TIME_STAMP));
 
 	memcpy(last_line,get_last_line(file,char_count), char_count);
 	last_line[char_count] = '\0';
-	last_time = atoi(get_entry(last_line, TIME_STAMP));
+	last_time = atoi(get_entry_from_line_position(last_line, TIME_STAMP));
 
 	if (last_time > first_time)
 		return 1;
@@ -228,7 +228,7 @@ int get_line_entry(FILE *file) {
 	int val;
 
 	getline(&line, &len, file);
-	val = atoi(get_entry(line, TIME_STAMP));
+	val = atoi(get_entry_from_line_position(line, TIME_STAMP));
 	return val;
 }
 

--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -16,7 +16,7 @@
 
 #define KB_TO_BYTE 1024
 #define MAX_FILE_SIZE 4096
-#define TIME_STAMP 2
+#define TIME_STAMP_POSITION 2
 
 off_t max_filesize = MAX_FILE_SIZE;
 int is_unchecked = 1;
@@ -165,11 +165,13 @@ int is_outdated(FILE *file, ssize_t char_count) {
 
 	fseek(file, 0, SEEK_SET);
 	getline(&line, &len, file);
-	first_time = atoi(get_entry_from_line_position(line, TIME_STAMP));
+	first_time = atoi(get_entry_from_line_position(line,
+						       TIME_STAMP_POSITION));
 
 	memcpy(last_line,get_last_line(file,char_count), char_count);
 	last_line[char_count] = '\0';
-	last_time = atoi(get_entry_from_line_position(last_line, TIME_STAMP));
+	last_time = atoi(get_entry_from_line_position(last_line,
+						      TIME_STAMP_POSITION));
 
 	if (last_time > first_time)
 		return 1;
@@ -228,7 +230,7 @@ int get_line_entry(FILE *file) {
 	int val;
 
 	getline(&line, &len, file);
-	val = atoi(get_entry_from_line_position(line, TIME_STAMP));
+	val = atoi(get_entry_from_line_position(line, TIME_STAMP_POSITION));
 	return val;
 }
 

--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -14,7 +14,7 @@
 #include <unistd.h>
 #include "config.h"
 
-#define MB_TO_BYTE 1048576
+#define KB_TO_BYTE 1024
 #define MAX_FILE_SIZE 4096
 #define TIME_STAMP 2
 
@@ -180,14 +180,14 @@ int is_outdated(FILE *file, ssize_t char_count) {
 /*
  * check if a file is above a given limit
  * @file: file to check
- * @max_size: maximal size of file in MB
+ * @max_size: maximal size of file in kB
  * return: returns 1 if file is above the limit, else 0
  */
 int has_max_size(char *powquty_path, off_t max_size) {
 	struct stat st;
 	off_t filesize;
 
-	max_size *= MB_TO_BYTE;
+	max_size *= KB_TO_BYTE;
 
 	if (access(powquty_path, F_OK ))
 		return 0;

--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -19,7 +19,7 @@
 #define TIME_STAMP_POSITION 2
 
 off_t max_filesize = MAX_FILE_SIZE;
-int is_unchecked = 1;
+int file_is_unchecked = 1;
 long cur_offset;
 
 void print_received_buffer(unsigned char* buf, int len) {
@@ -284,8 +284,8 @@ void store_to_file(PQResult pqResult, char *powquty_path) {
 		char_count = get_character_count_per_line(pf);
 		fseek(pf, -char_count, SEEK_END);
 		lower_bound = ftell(pf);
-		if (is_unchecked) {
-			is_unchecked = 0;
+		if (file_is_unchecked) {
+			file_is_unchecked = 0;
 
 			if (is_outdated(pf,char_count)) {
 				fseek(pf, 0, SEEK_SET);
@@ -297,13 +297,13 @@ void store_to_file(PQResult pqResult, char *powquty_path) {
 					     char_count);
 				cur_offset = ftell(pf);
 				if (cur_offset == lower_bound)
-					is_unchecked = 1;
+					file_is_unchecked = 1;
 			}
 		} else {
 			cur_offset += (long)get_character_count_per_line(pf);
 			fseek(pf, cur_offset, SEEK_SET);
 			if (cur_offset == lower_bound)
-				is_unchecked = 1;
+				file_is_unchecked = 1;
 		}
 	}
 	long long ts = get_curr_time_in_milliseconds();

--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -270,6 +270,9 @@ void set_position(FILE *file, long u_bound, long l_bound, ssize_t char_count) {
 		fseek(file, m_offset + char_count, SEEK_SET);
 }
 
+/*
+ * For a correct file write all line must have the same number of characters.
+ */
 void store_to_file(PQResult pqResult, char *powquty_path) {
 	FILE* pf;
 	ssize_t char_count;

--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -134,7 +134,7 @@ char * get_last_line(FILE *file, ssize_t char_count) {
  * @file: file to check for line length
  * return: returns character count of first line
  */
-ssize_t get_character_count(FILE *file) {
+ssize_t get_character_count_per_line(FILE *file) {
 	char *line = NULL;
 	size_t len = 0;
 	ssize_t char_count;
@@ -281,7 +281,7 @@ void store_to_file(PQResult pqResult, char *powquty_path) {
 			exit(EXIT_FAILURE);
 	} else {
 		pf = fopen(powquty_path, "r+");
-		char_count = get_character_count(pf);
+		char_count = get_character_count_per_line(pf);
 		fseek(pf, -char_count, SEEK_END);
 		lower_bound = ftell(pf);
 		if (is_unchecked) {
@@ -300,7 +300,7 @@ void store_to_file(PQResult pqResult, char *powquty_path) {
 					is_unchecked = 1;
 			}
 		} else {
-			cur_offset += (long)get_character_count(pf);
+			cur_offset += (long)get_character_count_per_line(pf);
 			fseek(pf, cur_offset, SEEK_SET);
 			if (cur_offset == lower_bound)
 				is_unchecked = 1;

--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -66,10 +66,10 @@ long long get_curr_time_in_milliseconds() {
 	return (long long) ( (tv.tv_sec * 1000) + (int)tv.tv_usec/1000 );
 }
 
-int get_curr_time_in_seconds() {
+long get_curr_time_in_seconds() {
 	struct timeval tv;
 	gettimeofday(&tv,NULL);
-	return (int) (tv.tv_sec);
+	return tv.tv_sec;
 }
 
 void print_PQ_Error(PQ_ERROR err) {
@@ -158,19 +158,19 @@ ssize_t get_character_count_per_line(FILE *file) {
  * return 0 if file write has to be resumed, 1 if the first entry is the oldest
  */
 int is_outdated(FILE *file, ssize_t char_count) {
-	int first_time, last_time;
+	long first_time, last_time;
 	char *line =NULL;
 	char *last_line = malloc((sizeof(char) * char_count) + 1);
 	size_t len = 0;
 
 	fseek(file, 0, SEEK_SET);
 	getline(&line, &len, file);
-	first_time = atoi(get_entry_from_line_position(line,
+	first_time = atol(get_entry_from_line_position(line,
 						       TIME_STAMP_POSITION));
 
 	memcpy(last_line,get_last_line(file,char_count), char_count);
 	last_line[char_count] = '\0';
-	last_time = atoi(get_entry_from_line_position(last_line,
+	last_time = atol(get_entry_from_line_position(last_line,
 						      TIME_STAMP_POSITION));
 
 	if (last_time > first_time)
@@ -227,10 +227,10 @@ long get_line_number(long offset, ssize_t char_count) {
 int get_line_entry(FILE *file) {
 	char *line = NULL;
 	size_t len = 0;
-	int val;
+	long val;
 
 	getline(&line, &len, file);
-	val = atoi(get_entry_from_line_position(line, TIME_STAMP_POSITION));
+	val = atol(get_entry_from_line_position(line, TIME_STAMP_POSITION));
 	return val;
 }
 
@@ -310,9 +310,9 @@ void store_to_file(PQResult pqResult, char *powquty_path) {
 		}
 	}
 	long long ts = get_curr_time_in_milliseconds();
-	int ts_sec = get_curr_time_in_seconds();
+	long ts_sec = get_curr_time_in_seconds();
 	fprintf(pf,
-			"%s,%d,%lld,3,%010.6f,%09.6f,%09.6f,%09.6f,%09.6f,%09.6f,"
+			"%s,%ld,%lld,3,%010.6f,%09.6f,%09.6f,%09.6f,%09.6f,%09.6f,"
 			"%09.6f,%09.6f,%09.6f\n",
 			"DEV_UUID",
 			ts_sec,

--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -215,10 +215,6 @@ int has_max_size(char *powquty_path, off_t max_size) {
 	return 0;
 }
 
-fpos_t get_start_of_line(FILE *file, fpos_t pos) {
-	fsetpos(file,
-}
-
 void store_to_file(PQResult pqResult, char *powquty_path) {
 	FILE* pf;
 	ssize_t line_length;
@@ -235,7 +231,7 @@ void store_to_file(PQResult pqResult, char *powquty_path) {
 		if (is_unchecked) {
 			is_unchecked = 0;
 			if (is_outdated(pf,line_length)) {
-				fsetpos(pf, first_valid_line);
+				fseek(file, 0 ,SEEK_SET);
 			} else {
 				//TODO: get position to resume file write
 			}

--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -19,7 +19,6 @@
 #define TIME_STAMP 2
 
 off_t max_filesize = MAX_FILE_SIZE;
-fpos_t first_valid_line;
 int is_unchecked = 1;
 
 void print_received_buffer(unsigned char* buf, int len) {
@@ -136,33 +135,18 @@ char * get_last_line(FILE *file, ssize_t char_count) {
  */
 ssize_t get_character_count(FILE *file) {
 	char *line = NULL;
-	char *next_line = NULL;
 	size_t len = 0;
-	size_t next_len = 0;
-	ssize_t reg_read, next_read = 0;
+	ssize_t char_count;
 
-	reg_read = getline(&line, &len, file);
+	fseek(file, 0, SEEK_SET);
+	char_count = getline(&line, &len, file);
 	if (reg_read == -1) {
-		printf("Error in line read: Could not get length of first line\n");
+		printf("Error in line read: Could not get number of characters"
+			" in first line\n");
 		exit(EXIT_FAILURE);
 	}
-	fseek(file, reg_read, SEEK_SET);
-	next_read = getline(&next_line, &next_len, file);
+	fseek(file, 0, SEEK_SET);
 
-	if (next_read == reg_read) {
-		fseek(file, -reg_read, SEEK_CUR);
-		fgetpos(file, &first_valid_line);
-		return reg_read;
-	}
-
-	if (next_read != -1) {
-		reg_read = next_read;
-	} else {
-		printf("Error in line read: Could not get length of line\n");
-		exit(EXIT_FAILURE);
-	}
-
-	fgetpos(file, &first_valid_line);
 	return reg_read;
 }
 
@@ -178,7 +162,7 @@ int is_outdated(FILE *file, ssize_t char_count) {
 	char *last_line = malloc((sizeof(char) * char_count) + 1);
 	size_t len = 0;
 
-	fsetpos(file, &first_valid_line);
+	fseek(file, 0, SEEK_SET);
 	getline(&line, &len, file);
 	first_time = atoi(get_entry(line, TIME_STAMP));
 

--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -264,7 +264,7 @@ void set_position(FILE *file, long u_bound, long l_bound, ssize_t char_count) {
 	if ((m_val < l_val) && (m_val < u_val))
 		set_position(file, u_offset, m_offset, char_count);
 	if ((m_val == u_val) || (m_val == l_val))
-		fseek(file, m_offset, SEEK_SET);
+		fseek(file, m_offset + char_count, SEEK_SET);
 }
 
 void store_to_file(PQResult pqResult, char *powquty_path) {

--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -140,14 +140,14 @@ ssize_t get_character_count(FILE *file) {
 
 	fseek(file, 0, SEEK_SET);
 	char_count = getline(&line, &len, file);
-	if (reg_read == -1) {
+	if (char_count == -1) {
 		printf("Error in line read: Could not get number of characters"
 			" in first line\n");
 		exit(EXIT_FAILURE);
 	}
 	fseek(file, 0, SEEK_SET);
 
-	return reg_read;
+	return char_count;
 }
 
 /*

--- a/powqutyd/files/src/mqtt.c
+++ b/powqutyd/files/src/mqtt.c
@@ -161,9 +161,9 @@ void publish_measurements(PQResult pqResult) {
 	// printf("publish_measurements: \n");
 	payload[0] = '\0';
 	long long ts = get_curr_time_in_milliseconds();
-	int ts_sec = get_curr_time_in_seconds();
+	long ts_sec = get_curr_time_in_seconds();
 	sprintf(payload,
-			"%s,%d,%lld,3,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f",
+			"%s,%ld,%lld,3,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f,%.6f",
 			dev_uuid,
 			ts_sec,
 			ts,


### PR DESCRIPTION
If the powquty log file hits max size we want to be able to write new entries from the first line
of the file. In addition, if powqutyd crasches, we want to be able to continue writing from last position. This pr introduces both functionalities.

is max file size reached?
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;->no: just append
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;->yes: has this been checked already?
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;->yes: write to current offset
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;->no: is the first line the oldest line?
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-> yes: write to first line
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-> no: go to offset in file after latest write

As logarithmic search is used, large files are parsed efficiently as well.
The position in the file is calculated by the offset of a line and the line parsed for its timestamp entry.

If the timestamp of the first line is older(smaller) as the timestamp of the last line we will resume writing from first line.
If powqutyd crashed, the timestamp of the first and last line will be compared. Depending on its values the interval is halved in each iteration and the boundaries for the search set accordingly until the latest(biggest) value is found.