### PR TITLE
(l)uci max log size

### DIFF
--- a/luci-app-powquty/luasrc/model/cbi/powquty/powquty.lua
+++ b/luci-app-powquty/luasrc/model/cbi/powquty/powquty.lua
@@ -28,5 +28,9 @@ powqutyd_print = s:option(Flag, "powqutyd_print", "powqutyd_print", "If activate
 powqutyd_print.rmempty = false
 powqutyd_print.default = true
 
+max_log_size_kb = s:option(Value, "max_log_size_kb", "max_log_size_kb", "Maximum size of log files in kB")
+max_log_size_kb.datatype = "string"
+max_log_size_kb.default = "4096"
+
 return m
 

--- a/powqutyd/files/etc/powqutyd.config
+++ b/powqutyd/files/etc/powqutyd.config
@@ -5,4 +5,5 @@ config powquty powquty
 	option dev_uuid 'BERTUB001'
 	option powquty_path '/tmp/powquty.log'
 	option powqutyd_print '1'
+	option max_log_size_kb '4096'
 	

--- a/powqutyd/files/include/helper.h
+++ b/powqutyd/files/include/helper.h
@@ -9,6 +9,7 @@
 #define HELPER_H_
 
 #include "PQ_App.h"
+#include "uci_config.h"
 
 long long get_curr_time_in_milliseconds();
 
@@ -24,6 +25,6 @@ unsigned short get_unsigned_short_val(unsigned char* buf);
 
 void print_PQ_Error(PQ_ERROR err);
 
-void store_to_file(PQResult pqResult, char *powquty_path);
+void store_to_file(PQResult pqResult, struct powquty_conf *config);
 
 #endif /* HELPER_H_ */

--- a/powqutyd/files/include/uci_config.h
+++ b/powqutyd/files/include/uci_config.h
@@ -18,6 +18,7 @@ struct powquty_conf {
 	char dev_uuid[32];
 	char powquty_path[32];
 	int powqutyd_print;
+	long max_log_size_kb;
 
 /*	option device_tty '/dev/ttyACM0'
 		option mqtt_host 'localhost'

--- a/powqutyd/files/src/calculation.c
+++ b/powqutyd/files/src/calculation.c
@@ -141,7 +141,7 @@ static void *calculation_thread_run(void* param) {
 			// print_results();
 
 			if(pqResult.HarmonicsExist) {
-				store_to_file(pqResult, &config->powquty_path);
+				store_to_file(pqResult, config);
 #ifdef MQTT
 				publish_measurements(pqResult);
 #endif

--- a/powqutyd/files/src/helper.c
+++ b/powqutyd/files/src/helper.c
@@ -15,10 +15,8 @@
 #include "config.h"
 
 #define KB_TO_BYTE 1024
-#define MAX_FILE_SIZE 4096
 #define TIME_STAMP_POSITION 2
 
-off_t max_filesize = MAX_FILE_SIZE;
 int file_is_unchecked = 1;
 long cur_offset;
 
@@ -273,17 +271,17 @@ void set_position(FILE *file, long u_bound, long l_bound, ssize_t char_count) {
 /*
  * For a correct file write all line must have the same number of characters.
  */
-void store_to_file(PQResult pqResult, char *powquty_path) {
+void store_to_file(PQResult pqResult, struct powquty_conf *config) {
 	FILE* pf;
 	ssize_t char_count;
 	long lower_bound, upper_bound;
 
-	if (!has_max_size(powquty_path, max_filesize)) {
-		pf = fopen(powquty_path,"a");
+	if (!has_max_size(config->powquty_path, (off_t)config->max_log_size_kb)) {
+		pf = fopen(config->powquty_path,"a");
 		if (pf == NULL)
 			exit(EXIT_FAILURE);
 	} else {
-		pf = fopen(powquty_path, "r+");
+		pf = fopen(config->powquty_path, "r+");
 		char_count = get_character_count_per_line(pf);
 		fseek(pf, -char_count, SEEK_END);
 		lower_bound = ftell(pf);

--- a/powqutyd/files/src/uci_config.c
+++ b/powqutyd/files/src/uci_config.c
@@ -17,6 +17,13 @@ static int uci_lookup_option_int(struct uci_context *uci, struct uci_section *s,
 	return str == NULL ? -1 : atoi(str);
 }
 
+static long uci_lookup_option_long(struct uci_context *uci,
+				   struct uci_section *s,
+				   const char *name) {
+	const char *str = uci_lookup_option_string(uci, s, name);
+	return str == NULL ? -1 : atol(str);
+}
+
 int uci_config_powquty(struct powquty_conf* conf) {
 	struct uci_context* uci;
 	struct uci_package* p;
@@ -29,6 +36,7 @@ int uci_config_powquty(struct powquty_conf* conf) {
 	char default_mqtt_topic[32] = "devices/update";
 	char default_dev_uuid[32] = "BERTUB001";
 	int default_powqutyd_print = 1;
+	long default_max_log_size_kb = 4096;
 
 	uci = uci_alloc_context();
 	if (uci == NULL)
@@ -50,6 +58,7 @@ int uci_config_powquty(struct powquty_conf* conf) {
 			strcpy(conf->powquty_path, default_powquty_path);
 
 			conf->powqutyd_print = default_powqutyd_print;
+			conf->max_log_size_kb = default_max_log_size_kb;
 
 			str = uci_lookup_option_string(uci, s, "dev_uuid");
 			if (str == NULL)
@@ -100,6 +109,9 @@ int uci_config_powquty(struct powquty_conf* conf) {
 
 			conf->powqutyd_print = uci_lookup_option_int(uci, s,
 					"powqutyd_print");
+
+			conf->max_log_size_kb = uci_lookup_option_long(uci, s,
+					"max_log_size_kb");
 
 		}
 	}


### PR DESCRIPTION
Enable the user to configure the maximum log size.
This can be done in the config file or in the web interface.