### PR TITLE
Add file read flag for powqutyd

### DIFF
--- a/powqutyd/files/include/calculation.h
+++ b/powqutyd/files/include/calculation.h
@@ -11,6 +11,19 @@
 #include "uci_config.h"
 
 /*
+ * use file instead of usb oscilloscope for data input
+ * @param path: file to use as input
+ * returns: 1 on failure, 0 else
+ */
+int set_file_read(const char* path);
+
+/*
+ * check if a file is used instead of a usb=oscilloscope for data input
+ * returns: 1 if file is used, else 0
+ */
+int get_input_file_state();
+
+/*
  * init function for the calculation functionality
  */
 int calculation_init(struct powquty_conf* conf);

--- a/powqutyd/files/src/main.c
+++ b/powqutyd/files/src/main.c
@@ -36,13 +36,16 @@ void stop_powqutyd() {
 
 void handle_args (int argc, char **argv) {
 	int c;
-	while ((c = getopt (argc, argv, "rd")) != -1) {
+	while ((c = getopt (argc, argv, "rdf:")) != -1) {
 		switch (c) {
 			case 'r':
 				set_raw_print(1);
 				break;
 			case 'd':
 				set_debug(1);
+				break;
+			case 'f':
+				set_file_read(optarg);
 				break;
 			default:
 				break;


### PR DESCRIPTION
To use a file instead of the regular usb oscilloscope input start PowQuty with
`powqutyd -f /path/to/file`

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>