### PR TITLE
Add dash to event log file

### DIFF
--- a/powqutyd/files/src/event_handling.c
+++ b/powqutyd/files/src/event_handling.c
@@ -120,7 +120,7 @@ void send_event(PQEvent pqe, struct powquty_conf *conf) {
 			pqe.startTime,
 			pqe.length);
 	if (volt_event)
-		fprintf(file, ",%9.6f\n", pqe.minMax);
+		fprintf(file, ",%9.6f,-\n", pqe.minMax);
 	else if (harm_event)
 		fprintf(file, ",%d,%d\n", pqe.harmonic_number,
 					  pqe.fail_percentage);


### PR DESCRIPTION
This is necessary so that every line in the event log
has an equal number of coma separated entries

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>