### PR TITLE
Add missing path to event log file

### DIFF
--- a/luci-app-powquty/Makefile
+++ b/luci-app-powquty/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-powquty
-PKG_VERSION:=0.1
+PKG_VERSION:=0.2
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Tobias Ilte <Email ?>
 PKG_LICENSE:=GPL-3.0+

--- a/luci-app-powquty/luasrc/model/cbi/powquty/powquty.lua
+++ b/luci-app-powquty/luasrc/model/cbi/powquty/powquty.lua
@@ -19,6 +19,10 @@ powquty_path = s:taboption("general", Value, "powquty_path", "powquty_path", "Th
 powquty_path.datatype = "string"
 powquty_path.default = "/tmp/powquty.log"
 
+powquty_event_path = s:taboption("general", Value, "powquty_event_path", "powquty_event_path", "The path of the event output logfile")
+powquty_event_path = "string"
+powquty_event_path = "/tmp/powqutyy_event.log"
+
 powqutyd_print = s:taboption("general", Flag, "powqutyd_print", "powqutyd_print", "If activated, will print the results published to the MQTT broker to stdout")
 powqutyd_print.rmempty = false
 powqutyd_print.default = true


### PR DESCRIPTION
The parameter for the event log file is missing in the
web interface, ad it.

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>