### PR TITLE
Added missing import of uci in Luci app

### DIFF
--- a/luci-app-powquty/luasrc/controller/powquty/powquty.lua
+++ b/luci-app-powquty/luasrc/controller/powquty/powquty.lua
@@ -1,6 +1,7 @@
 module("luci.controller.powquty.powquty", package.seeall)
 
 require ("lfs")
+require ("uci")
 -- require("luci.i18n")
 local event_path = uci.get("powquty", "powquty", "powquty_event_path") or "/tmp/powquty_event.log"
 local epoch = tonumber(os.time())


### PR DESCRIPTION
This fixes and error when /tmp/powquty_event.log is not available

Signed-off-by: Tobias Ilte <tobias.ilte@campus.tu-berlin.de>